### PR TITLE
Fix apis

### DIFF
--- a/src/pages/api/createIDVId.ts
+++ b/src/pages/api/createIDVId.ts
@@ -53,16 +53,16 @@ export const POST: APIRoute = async ({ request }: { request: Request }) => {
 				const kycStatus = await _d.json
 					.get(recordKey)
 					.then((res) => res as KYCStatus)
+					.then((res) =>
+						res && res.status ? res.status.toLowerCase() : 'unverified',
+					)
 					.catch((err) => new Error(err))
 
-				return kycStatus &&
-					(kycStatus instanceof Error ||
-						kycStatus.status === 'Completed' ||
-						kycStatus.status === 'Approved')
-					? new Error(
-							kycStatus instanceof Error ? kycStatus.message : 'KYC in process',
-						)
-					: true
+				return !kycStatus || kycStatus instanceof Error
+					? new Error('Could not fetch user status')
+					: kycStatus !== 'approved'
+						? true
+						: new Error('KYC is already approved')
 			}) ?? new Error('Could not fetch user status'),
 	)
 

--- a/src/pages/api/user-status.ts
+++ b/src/pages/api/user-status.ts
@@ -32,9 +32,10 @@ export const GET = async ({ request }: { request: Request }) => {
 			return new Response(
 				json({
 					data: {
-						status: isNotError(result)
-							? result?.status || 'Unverified'
-							: 'Unverified',
+						status:
+							result && isNotError(result) && result.status
+								? result.status.toLowerCase()
+								: 'unverified',
 					},
 				}),
 				{

--- a/src/pages/api/webhooks/ondato/index.ts
+++ b/src/pages/api/webhooks/ondato/index.ts
@@ -26,9 +26,6 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
 		.then((x) => x as RequestBody)
 		.catch((err) => new Error(err))
 
-	// eslint-disable-next-line functional/no-expression-statements
-	console.log({ body })
-
 	const isValidRequest = auth(clientAddress)
 		? true
 		: new Error('Authentication failed')
@@ -48,6 +45,9 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
 				}),
 			) ?? new Error('Webhook payload params undefined'),
 	)
+
+	// eslint-disable-next-line functional/no-expression-statements
+	console.log({ props })
 
 	const result = await whenNotErrorAll(
 		[props, db, isValidRequest],

--- a/src/pages/api/webhooks/ondato/index.ts
+++ b/src/pages/api/webhooks/ondato/index.ts
@@ -26,6 +26,9 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
 		.then((x) => x as RequestBody)
 		.catch((err) => new Error(err))
 
+	// eslint-disable-next-line functional/no-expression-statements
+	console.log({ body })
+
 	const isValidRequest = auth(clientAddress)
 		? true
 		: new Error('Authentication failed')

--- a/src/pages/api/webhooks/ondato/index.ts
+++ b/src/pages/api/webhooks/ondato/index.ts
@@ -72,11 +72,13 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
 			 */
 			const updateStatus = await whenNotError(records, async (_records) => {
 				const promises = _records.documents.map((record) => {
-					const updatedRecord = {
-						...record.value,
-						status: data.status,
-					}
-					return client.json.set(record.id, '$', updatedRecord)
+					const newStatus: string = data.status.toLowerCase()
+					return newStatus === 'completed'
+						? 'OK' // Ignore if status is coming as `COMPLETED`, don't save it in the db.
+						: client.json.set(record.id, '$', {
+								...record.value,
+								status: newStatus,
+							})
 				})
 
 				return await Promise.all(promises)


### PR DESCRIPTION
- If the new status incoming from `Ondato` is `COMPLETED` or `completed` ignore it, this will enable us to save last status like (approved, rejected, awaiting, etc) in our DB.
- Allow generating new IDV id only if the KYC status is not `approved`. (That means all other statuses like in-progess, pending, awaiting will allow creating new IDV ids)
- Standardize the status text to lower case.